### PR TITLE
perf: add peer cache to optimize auto-registration checks

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "active_message_example"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 dynamo-am = { path = ".." }

--- a/src/zmq/manager.rs
+++ b/src/zmq/manager.rs
@@ -233,6 +233,9 @@ impl ZmqActiveMessageManager {
 
         manager.register_builtin_handlers().await?;
 
+        // Initialize peer cache before starting message processing
+        manager.message_router.initialize_peer_cache().await;
+
         // Spawn transport reader tasks for both TCP and IPC
         let _tcp_reader_task = tokio::spawn(Self::transport_reader_task(
             tcp_transport,


### PR DESCRIPTION
Replace list_peers() calls with cached HashSet lookup to eliminate lock contention and iteration overhead on every incoming message.

Changes:
- Add known_peers cache (Arc<RwLock<HashSet<Uuid>>>) to MessageRouter
- Initialize cache from list_peers() on router creation
- Update convert_to_dispatch_message() to use cached lookup
- Update handle_auto_registration() to use cached lookup
- Update cache when auto-registering new peers

Performance impact:
- Eliminates RwLock acquisition + vector iteration per message
- O(1) HashSet lookup instead of O(n) linear search
- Reduces lock contention on peer list

Phase 1.4: Auto-Registration Cache optimization